### PR TITLE
add key-dist command line option

### DIFF
--- a/postgres/src/jepsen/postgres/cli.clj
+++ b/postgres/src/jepsen/postgres/cli.clj
@@ -131,6 +131,12 @@
     :parse-fn parse-long
     :validate [pos? "Must be a positive integer"]]
 
+   [nil "--key-dist DISTRIBUTION" "Key distribution pattern for workload generation."
+    :default :exponential
+    :parse-fn keyword
+    :validate [#{:uniform :exponential}
+               "Should be one of uniform or exponential"]]
+
    [nil "--nemesis FAULTS" "A comma-separated list of nemesis faults to enable"
      :parse-fn parse-nemesis-spec
      :validate [(partial every? #{:pause :kill :partition :clock :member})

--- a/postgres/src/jepsen/postgres/workload/append.clj
+++ b/postgres/src/jepsen/postgres/workload/append.clj
@@ -234,6 +234,7 @@
   "A list append workload."
   [opts]
   (-> (append/test (assoc (select-keys opts [:key-count
+                                             :key-dist
                                              :max-txn-length
                                              :max-writes-per-key])
                           :min-txn-length 1

--- a/rds/src/jepsen/postgres/rds.clj
+++ b/rds/src/jepsen/postgres/rds.clj
@@ -79,6 +79,12 @@
     :parse-fn parse-long
     :validate [pos? "Must be a positive integer"]]
 
+   [nil "--key-dist DISTRIBUTION" "Key distribution pattern for workload generation."
+    :default :exponential
+    :parse-fn keyword
+    :validate [#{:uniform :exponential}
+               "Should be one of uniform or exponential"]]
+
    [nil "--nemesis FAULTS" "A comma-separated list of nemesis faults to enable"
      :parse-fn parse-nemesis-spec
      :validate [(partial every? #{})


### PR DESCRIPTION
I'm using jepsen with open source postgres to test for correctness across cluster reconfigurations. The uniform distribution enables me to push a lot more throughput with a higher number of writes per key, which has made it very simple to tease out G0/incompatible-order failures under some common misconfigurations (and default settings). I'll write up some more info soon, but wanted to submit the PR for exposing the key-dist as a CLI option since it was very useful for this testing.